### PR TITLE
Add timer ability to set and remove reset button its useless

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -97,6 +97,63 @@ h1 {
   box-shadow: 0 6px 20px rgba(79, 172, 254, 0.4);
 }
 
+/* Timer Controls */
+.timer-section {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.timer-controls {
+  transition: opacity 0.8s ease;
+}
+
+.timer-controls.faded {
+  opacity: 0;
+}
+
+.timer-controls label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.timer-inputs {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+}
+
+.timer-btn {
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
+}
+
+.timer-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.timer-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.timer-display {
+  font-size: 0.9rem;
+  color: #64c8ff;
+  margin: 0.5rem 0 0 0;
+  font-weight: 500;
+}
+
 .breathing-container {
   display: flex;
   flex-direction: column;
@@ -197,18 +254,6 @@ h1 {
 .control-btn.stop:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(255, 107, 107, 0.4);
-}
-
-.control-btn.reset {
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-}
-
-.control-btn.reset:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(255, 255, 255, 0.2);
 }
 
 .stats {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,6 +164,9 @@ function App() {
         setRemainingTime(timerMinutes * 60);
       }
 
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+      }
       timerRef.current = setInterval(() => {
         setRemainingTime(time => {
           if (time <= 1) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,7 +184,7 @@ function App() {
         clearInterval(timerRef.current);
       }
     };
-  }, [isActive, timerMinutes, breathingType]);
+  }, [isActive, timerMinutes, breathingType, remainingTime]);
 
   const handleStartStop = () => {
     setIsActive(!isActive);


### PR DESCRIPTION
## What does this PR do?

This pull request adds a session timer feature for non-4-7-8 breathing exercises, allowing users to set a session duration and see the time remaining. It also introduces related UI changes and code refactoring to support the timer. Additionally, the reset button and its styling have been removed.

## Type of change
- [ ] Bug fix
- [ ] New breathing technique
- [x] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

## Testing
- [x] I have tested these changes locally
- [x] The app runs without errors
- [x] All breathing techniques work as expected

## Screenshots (if applicable)

<img width="942" height="1017" alt="firefox_wo2BNNPIGk" src="https://github.com/user-attachments/assets/fe391c05-73d9-4bf7-8a25-ea3528594927" />



## Additional notes
<!-- Any other information that would be helpful for reviewers -->
