### PR TITLE
Tighten breathing-container styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -343,8 +343,6 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
-  margin: 2rem 0;
 }
 
 .breathing-visual {


### PR DESCRIPTION


## What does this PR do?

Removed gap and margin from breathing-container.

Closes #18

## Type of change
- [x] Bug fix
- [ ] New breathing technique
- [ ] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

## Testing
- [x] I have tested these changes locally
- [x] The app runs without errors
- [x] All breathing techniques work as expected

## Screenshots (if applicable)

<img width="844" height="665" alt="HearthstoneDeckTracker_SbMma7TyDm" src="https://github.com/user-attachments/assets/27cd439c-143e-4246-842f-e5f84a8f3f03" />
<img width="856" height="638" alt="HearthstoneDeckTracker_WzZ02FAtr0" src="https://github.com/user-attachments/assets/58f0711e-dfac-4042-b8f8-7e7085b6ebc1" />

