### PR TITLE
Sticky button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -405,6 +405,25 @@ h1 {
   margin: 2rem 0;
 }
 
+.sticky-controls {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.sticky-controls .control-btn {
+  margin: 0;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
 .control-btn {
   padding: 12px 24px;
   border: none;
@@ -637,32 +656,32 @@ h1 {
   .exercise-btn {
     width: 200px;
   }
-  
+
   .settings-menu {
     top: 15px;
     right: 15px;
   }
-  
+
   .settings-toggle {
     min-width: 100px;
     padding: 6px 12px;
     font-size: 0.75rem;
   }
-  
+
   .settings-content {
     min-width: 260px;
     right: -10px;
   }
-  
+
   .toggle-buttons {
     gap: 0.5rem;
   }
-  
+
   .toggle-btn {
     min-width: 85px;
     font-size: 0.8rem;
   }
-  
+
   .settings-content.open {
     padding: 1rem;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,9 +110,11 @@ function App() {
   const [isRaining, setIsRaining] = useState(false);
   const [useShapes, setUseShapes] = useState(false); // Toggle between shapes and circles - default to circles
   const [isSettingsOpen, setIsSettingsOpen] = useState(false); // Toggle for settings menu
+  const [isStartButtonVisible, setIsStartButtonVisible] = useState(true); // Track if start button is visible
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const startButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const currentExercise = breathingExercises[breathingType];
   const phaseDuration = currentExercise.phaseDurations[phase];
@@ -192,6 +194,29 @@ function App() {
       }
     };
   }, [isActive, timerMinutes, breathingType, remainingTime]);
+
+  // Intersection Observer for start button visibility
+  useEffect(() => {
+    const startButton = startButtonRef.current;
+    if (!startButton) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsStartButtonVisible(entry.isIntersecting);
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.9 // Button is considered visible if 90% is visible
+      }
+    );
+
+    observer.observe(startButton);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   const handleStartStop = () => {
     setIsActive(!isActive);
@@ -979,12 +1004,25 @@ function App() {
 
         <div className="controls">
           <button
+            ref={startButtonRef}
             className={`control-btn ${isActive ? 'stop' : 'start'}`}
             onClick={handleStartStop}
           >
             {isActive ? 'Pause' : 'Start'}
           </button>
         </div>
+
+        {/* Sticky button that appears when main button is not visible */}
+        {!isStartButtonVisible && (
+          <div className="sticky-controls">
+            <button
+              className={`control-btn ${isActive ? 'stop' : 'start'}`}
+              onClick={handleStartStop}
+            >
+              {isActive ? 'Pause' : 'Start'}
+            </button>
+          </div>
+        )}
 
         <div className="stats">
           <p>Completed Cycles: <span className="cycle-count">{cycleCount}</span>


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a "sticky" Start/Pause button that appears at the bottom of the screen when the main control button is not visible, improving usability for users on long or scrollable pages. The implementation uses an Intersection Observer to track the visibility of the main button and conditionally renders the sticky version as needed. 

Closes #23

## Type of change
- [ ] Bug fix
- [ ] New breathing technique
- [x] UI/UX improvement
- [ ] Documentation update
- [ ] Other (please specify):

## Testing
- [x] I have tested these changes locally
- [x] The app runs without errors
- [x] All breathing techniques work as expected

## Screenshots (if applicable)


<img width="1051" height="768" alt="firefox_dnxvFWC8qp" src="https://github.com/user-attachments/assets/592e81a6-eeb3-47ef-925b-556cd3cb040f" />

